### PR TITLE
Remove setting password for new employee

### DIFF
--- a/src/components/admin/employee/AddEmployee.js
+++ b/src/components/admin/employee/AddEmployee.js
@@ -18,14 +18,6 @@ class AddEmployee extends Component {
                             </div>
                         </div>
                     </div>
-                    <div className='row'>
-                        <div className='col-6'>
-                            <div className='form-group'>
-                                <label for='password'>Password</label>
-                                <input type='password' className='form-control' id='password' placeholder='Password' />
-                            </div>
-                        </div>
-                    </div>
                     <hr />
                     <div className='card'>
                         <div className='card-body bg-light'>


### PR DESCRIPTION
When creating an new employee, the employee's password will be generated in the
backgroun.